### PR TITLE
ASDPLNG-49 dont run client setup on xcat server

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -5,5 +5,12 @@
 # @example
 #   include profile_xcat::client
 class profile_xcat::client {
-  include ::profile_xcat::client::ssh
+
+  $master_node_ip = lookup( 'profile_xcat::master_node_ip' )
+  $my_ip = $facts['networking']['ip']
+
+  # OK to run if this is not the xcat server
+  if $master_node_ip != $my_ip {
+    include ::profile_xcat::client::ssh
+  }
 }


### PR DESCRIPTION
Added a check in client.pp to prevent running on the xcat server.

The settings are quite likely safe, though seem inane and might also cause issues with security vetting on xcat server nodes so added the check just to error on the side of caution.