### PR TITLE
Set /etc/exports option to ro instead of rw

### DIFF
--- a/manifests/master/nfs.pp
+++ b/manifests/master/nfs.pp
@@ -9,7 +9,7 @@ class profile_xcat::master::nfs {
 
   $mgmt_networks = lookup( 'profile_xcat::mgmt_net_cidrs', Array )
 
-  $common_options = [ 'rw', 'no_root_squash', 'sync', 'no_subtree_check' ]
+  $common_options = [ 'ro', 'no_root_squash', 'sync', 'no_subtree_check' ]
 
   $mount_points = {
     '/tftpboot' => $common_options,


### PR DESCRIPTION
Per SVC-4623 we think options on /etc/exports can be set to ro instead of rw. I tested changing these on ngale-adm01, and verified that backup-node_configs.sh still works. So don't think there is a reason why it needs to be rw.