### PR TITLE
SECURITY-1324 define ports in hiera, add toggle for bmc_smtp

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,18 +73,22 @@ profile_xcat::ipmi_bind_ip: "172.28.16.67"
 
 ## Reference
 
-### class profile_xcat (
--  Array $ipmi_net_cidrs,
--  Array $mgmt_net_cidrs,
--  String $master_node_ip,
--  String $ipmi_bind_ip,
+### class profile_xcat::master::firewall (
+-  Hash $net_port_map,
 ### class profile_xcat::master::root (
 -  String $sshkey_pub,
 -  String $sshkey_priv,
 -  String $sshkey_type,
+### class profile_xcat::master::bmc_smtp (
+-  Boolean $enable_bmc_smtp,
 ### define profile_xcat::master::nfs::export (
 -  String $mount_point,
 -  String $network,
 -  Array  $options,
+### class profile_xcat (
+-  Array $ipmi_net_cidrs,
+-  Array $mgmt_net_cidrs,
+-  String $master_node_ip,
+-  Optional[ String ] $ipmi_bind_ip,
 
 [REFERENCE.md](REFERENCE.md)

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -10,7 +10,7 @@
 * [`profile_xcat::client`](#profile_xcatclient): Setup access from xcat master to xcat client
 * [`profile_xcat::client::ssh`](#profile_xcatclientssh): Allow passwdless root access from xcat master node
 * [`profile_xcat::master`](#profile_xcatmaster): Configure an xcat master node.
-* [`profile_xcat::master::bmc_smtp`](#profile_xcatmasterbmc_smtp): Forward email from node BMC's to MDA on local (master) node
+* [`profile_xcat::master::bmc_smtp`](#profile_xcatmasterbmc_smtp): Setup xinetd to allow forwarding email from node BMC's to MDA on local (master) node
 * [`profile_xcat::master::firewall`](#profile_xcatmasterfirewall): Open firewall for xcat services on mgmt and ipmi networks
 * [`profile_xcat::master::nfs`](#profile_xcatmasternfs): Harden NFS settings on xcat-master
 * [`profile_xcat::master::root`](#profile_xcatmasterroot): Setup root account
@@ -31,9 +31,9 @@ Defines variables that are used by xcat::master and xcat::client
 The following parameters are available in the `profile_xcat` class:
 
 * [`ipmi_net_cidrs`](#ipmi_net_cidrs)
-* [`ipmi_bind_ip`](#ipmi_bind_ip)
 * [`mgmt_net_cidrs`](#mgmt_net_cidrs)
 * [`master_node_ip`](#master_node_ip)
+* [`ipmi_bind_ip`](#ipmi_bind_ip)
 
 ##### <a name="ipmi_net_cidrs"></a>`ipmi_net_cidrs`
 
@@ -55,10 +55,9 @@ IP of xCAT master node
 
 ##### <a name="ipmi_bind_ip"></a>`ipmi_bind_ip`
 
-Data type: `String`
+Data type: `Optional[ String ]`
 
-IP of the interface which bind for IPMI. 
-This is generally for machines where the IPMI is routed.
+
 
 ### <a name="profile_xcatclient"></a>`profile_xcat::client`
 
@@ -86,9 +85,21 @@ Includes all subordinate classes.
 
 ### <a name="profile_xcatmasterbmc_smtp"></a>`profile_xcat::master::bmc_smtp`
 
-Forward email from node BMC's to MDA on local (master) node
+Setup xinetd to allow forwarding email from node BMC's to MDA on local (master) node
 
 Automatically included by profile_xcat::master
+
+#### Parameters
+
+The following parameters are available in the `profile_xcat::master::bmc_smtp` class:
+
+* [`enable_bmc_smtp`](#enable_bmc_smtp)
+
+##### <a name="enable_bmc_smtp"></a>`enable_bmc_smtp`
+
+Data type: `Boolean`
+
+Enable/disable the xinetd service allowing xcat nodes to send to xcat master. Default enabled
 
 ### <a name="profile_xcatmasterfirewall"></a>`profile_xcat::master::firewall`
 
@@ -98,6 +109,19 @@ Required ports list at:
 https://xcat-docs.readthedocs.io/en/stable/advanced/ports/xcat_ports.html
 
 Automatically included by profile_xcat::master
+
+#### Parameters
+
+The following parameters are available in the `profile_xcat::master::firewall` class:
+
+* [`net_port_map`](#net_port_map)
+
+##### <a name="net_port_map"></a>`net_port_map`
+
+Data type: `Hash`
+
+Hash of hashes defining the Network (MGMT or IPMI, both required), the protocol (tcp or udp),
+and the port(s) to open. See common.yaml for example
 
 ### <a name="profile_xcatmasternfs"></a>`profile_xcat::master::nfs`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,6 +1,39 @@
 ---
 #empty values to allow for client to run without errors
 profile_xcat::master_node_ip: ""
+
+profile_xcat::master::bmc_smtp::enable_bmc_smtp: true
+
+profile_xcat::master::firewall::net_port_map:
+  MGMT:
+    tcp:
+      - 53    # DNS
+      - 67    # DHCP
+      - 68    # BOOTP
+      - 69    # TFTP
+      - 80    # HTTP
+      - 123   # NTP
+      - 514   # Rsyslog
+      - 782   # Conserver
+      - 873   # Rsync
+      - 2049  # nfsd
+      - 3001  # xcatdport
+      - 3002  # xcatiport
+      - 4011  # PXE
+    udp:
+      - 53    # DNS
+      - 67    # DHCP
+      - 69    # TFTP
+      - 80    # HTTP
+      - 514   # Rsyslog
+      - 873   # Rsync
+      - 2049  # nfsd
+      - 3001  # xcatdport
+      - 3002  # xcatiport
+  IPMI:
+    tcp:
+      - 25    # SMTP
+
 profile_xcat::master::root::sshkey_pub: ""
 #xCAT doesn't seem to support other key types at the moment
 profile_xcat::master::root::sshkey_type: "rsa"

--- a/manifests/master/bmc_smtp.pp
+++ b/manifests/master/bmc_smtp.pp
@@ -1,52 +1,63 @@
-# @summary Forward email from node BMC's to MDA on local (master) node
+# @summary Setup xinetd to allow forwarding email from node BMC's to MDA on local (master) node
 #
-# Forward email from node BMC's to MDA on local (master) node
+# Setup xinetd to allow forwarding email from node BMC's to MDA on local (master) node
+#
+# @param enable_bmc_smtp
+#   Enable/disable the xinetd service allowing xcat nodes to send to xcat master. Default enabled
 #
 # Automatically included by profile_xcat::master
-class profile_xcat::master::bmc_smtp {
+class profile_xcat::master::bmc_smtp (
+  Boolean $enable_bmc_smtp,
+) {
 
   include ::xinetd
 
-  #Check for defined bind address
-  $ipmi_bind_ip = lookup( 'profile_xcat::ipmi_bind_ip', String, 'first', undef )
+  if ($enable_bmc_smtp) {
+    #Check for defined bind address
+    $ipmi_bind_ip = lookup( 'profile_xcat::ipmi_bind_ip', undef, undef, undef )
 
-  #If defined set the bind IP and verify the correct IP address
-  if ( $ipmi_bind_ip != undef ) {
-    if ( $ipmi_bind_ip =~ Stdlib::IP::Address::V4 ) {
-      $bind_ip = $ipmi_bind_ip
+    #If defined set the bind IP and verify the correct IP address
+    if ( $ipmi_bind_ip != undef ) {
+      if ( $ipmi_bind_ip =~ Stdlib::IP::Address::V4 ) {
+        $bind_ip = $ipmi_bind_ip
+      } else {
+        $bind_ip = ''
+        notify{'$ipmi_bind_ip is not a valid IP address': }
+      }
     } else {
-      $bind_ip = ''
-      notify{'$ipmi_bind_ip is not a valid IP address': }
-    }
-  }
-  #Discover the IP address from puppet facts
-  else {
-    # Get IPMI network CIDR
-    $ipmi_networks = lookup( 'profile_xcat::ipmi_net_cidrs', Array )
-    $ipmi_networks.each | $cidr | {
-      # Validate proper network address for IPMI network
-      $tgt_net = ip_address( ip_network( $cidr ) )
+      #Discover the IP address from puppet facts
+      # Get IPMI network CIDR
+      $ipmi_networks = lookup( 'profile_xcat::ipmi_net_cidrs', Array )
+      $ipmi_networks.each | $cidr | {
+        # Validate proper network address for IPMI network
+        $tgt_net = ip_address( ip_network( $cidr ) )
 
-      # Check all local ip's if any match one of the $ipmi_networks
-      $bind_ip = $facts['networking']['interfaces'].reduce('') | $memo, $kv | {
-        # $kv is [ interface_name , interface_data ]
-        $if_name = $kv[0]
-        $interface_data = $kv[1]
-        $ip = $interface_data['ip']
-        $network = $interface_data['network']
-        if $network == $tgt_net {
-          $interface_data['ip']
-        } else {
-          $memo
+        # Check all local ip's if any match one of the $ipmi_networks
+        $bind_ip = $facts['networking']['interfaces'].reduce('') | $memo, $kv | {
+          # $kv is [ interface_name , interface_data ]
+          $if_name = $kv[0]
+          $interface_data = $kv[1]
+          $ip = $interface_data['ip']
+          $network = $interface_data['network']
+          if $network == $tgt_net {
+            $interface_data['ip']
+          } else {
+            $memo
+          }
         }
       }
     }
+
+    $ensure = $bind_ip ? {
+      String[1] => 'present',
+      default   => 'absent',
+    }
+
+  } else {
+    # Make sure xinetd service is absent
+    $ensure = 'absent'
   }
 
-  $ensure = $bind_ip ? {
-    String[1] => 'present',
-    default   => 'absent',
-  }
   ::xinetd::service { 'bmc_smtp':
     ensure       => $ensure,
     service_type => 'UNLISTED',
@@ -58,5 +69,4 @@ class profile_xcat::master::bmc_smtp {
     port         => '25',
     redirect     => 'localhost 25',
   }
-
 }

--- a/manifests/master/firewall.pp
+++ b/manifests/master/firewall.pp
@@ -2,11 +2,17 @@
 #
 # Open firewall for xcat services on mgmt and ipmi networks
 #
+# @param net_port_map
+#   Hash of hashes defining the Network (MGMT or IPMI, both required), the protocol (tcp or udp),
+#   and the port(s) to open. See common.yaml for example
+#
 # Required ports list at:
 # https://xcat-docs.readthedocs.io/en/stable/advanced/ports/xcat_ports.html
 #
 # Automatically included by profile_xcat::master
-class profile_xcat::master::firewall {
+class profile_xcat::master::firewall (
+  Hash $net_port_map,
+){
 
   # Get required values from hiera, ensure they are not empty
   # network CIDR has a min length of 11 (x.x.x.x/nn)
@@ -22,16 +28,6 @@ class profile_xcat::master::firewall {
   }
   # combine the hashes
   $all_nets = $m_nets + $i_nets
-
-  $net_port_map = {
-    'MGMT' => {
-      'tcp' => [ 53, 67, 68, 69, 80, 123, 514, 782, 873, 2049, 3001, 3002, 4011 ],
-      'udp' => [ 53, 69, 80, 514, 873, 2049, 3001, 3002 ],
-    },
-    'IPMI' => {
-      'tcp' => [ 25 ]
-    },
-  }
 
   # For each network, for each protocol, add firewall exceptions for the ports
   # Outer loop is the networks passed in, so if any were empty lists, nothing


### PR DESCRIPTION
Setting up xcat server ports to be defined in hiera so they are not hard-coded.

Add a new Boolean to enable/disable the xinetd service for accepting
SMTP from nodes BMC interfaces

Fix lookup for ipmi_bind_ip in manifests/master/bmc_smtp.pp. Before it
was set to:
lookup( 'profile_xcat::ipmi_bind_ip', String, 'first', undef )
If ipmi_bind_ip was not given in hiera the lookup would fail because the
default value given 'undef' does not match the variable type String.
To fix this changed the lookup function to this:
lookup( 'profile_xcat::ipmi_bind_ip', undef, undef, undef )
Which will lookup and use the value given in hiera, if none given use
undef instead