### PR TITLE
SVCPLAN-606 Allow xinetd to be disabled

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -99,7 +99,7 @@ The following parameters are available in the `profile_xcat::master::bmc_smtp` c
 
 Data type: `Boolean`
 
-Enable/disable the xinetd service allowing xcat nodes to send to xcat master. Default enabled
+Enable/disable the xinetd service allowing xcat nodes to send to xcat master.
 
 ### <a name="profile_xcatmasterfirewall"></a>`profile_xcat::master::firewall`
 


### PR DESCRIPTION
We cannot include upstream ::xinetd without it starting the xinetd
service. So need to setup bmc_smtp.pp so that it can still
remove the bmc_smtp xinetd service file and restart xinetd when
enable_bmc_smtp is set to false, all without including ::xinetd

This isn't pretty, but it does that