### PR TITLE
SVCPLAN-7367: Fix script_build_genders script to skip nodes without x…

### DIFF
--- a/templates/script_build_genders.erb
+++ b/templates/script_build_genders.erb
@@ -13,7 +13,6 @@ with open(pdsh_hosts, 'w') as host_file:
     for line in lines:
         if line.startswith('Object name:'):
             node = line.split(': ')[1].strip()
-            host_file.write(f"{node}  ")
         elif line.startswith('    groups='):
             groups = line.split('=')[1].strip()
-            host_file.write(f"{groups}\n")
+            host_file.write(f"{node}  {groups}\n")


### PR DESCRIPTION
…cat groups

This change to the script was manually tested on `mf-adm03`, but not tested via Puppet. It is not very straightforward to test with that host via Puppet.